### PR TITLE
任意のパスをビルドキャッシュから除外する custom-cache-path を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@
   with:
     maven-test-command: "test -DfailIfNoTests=false -Dtest='!IntegrationTest'"
     maven-settings-xml-path: "${{ github.workspace }}/settings.xml"
-    custom-cache-path: '!~/.m2/repository/com'
+    custom-cache-path: '!~/.m2/repository/com/subdomain'
     push-on-success: 'true'
 ```
 
-`custom-cache-path` は [actions/cache](https://github.com/actions/cache) に渡す `path` を記述します。`!` を使うことでキャッシュ対象から除外できます。この例では `~/.m2/repository/com` 配下のディレクトリをすべてキャッシュしない設定になります。
+`custom-cache-path` は [actions/cache](https://github.com/actions/cache) に渡す `path` を記述します。`!` を使うことでキャッシュ対象から除外できます。この例では `~/.m2/repository/com/subdomain` 配下のディレクトリをすべてキャッシュしない設定になります。
 
 リポジトリに push するには GITHUB_TOKEN や permissions といった認証情報を適切に設定する必要があります。
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
     push-on-success: 'true'
 ```
 
-`custom-cache-path` は [actions/cache](https://github.com/actions/cache) に渡す `path` を記述します。`!` を使うことでキャッシュ対象から除外できます。この例では `~/.m2/repository/com/subdomain` 配下のディレクトリをすべてキャッシュしない設定になります。
+`custom-cache-path` は [actions/cache](https://github.com/actions/cache) に渡す `path` を記述します。`!` を使うことでキャッシュ対象から除外できます。この例では `~/.m2/repository/com/subdomain` 配下のディレクトリをすべてキャッシュしない設定になります。除外設定には [actions/toolkit/issues/713](https://github.com/actions/toolkit/issues/713#issuecomment-850321461) で報告されている課題があり、`~/.m2/repository/第1階層/第2階層` のように2階層にあわせて指定する必要があります。
 
 リポジトリに push するには GITHUB_TOKEN や permissions といった認証情報を適切に設定する必要があります。
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,24 @@
     # デフォルト: 'false'
     display-dependency-updates: ''
 
-    # GitHub Actions が提供するビルドキャッシュを利用するかどうか
+    # GitHub Actions が提供するビルドキャッシュ (actions/cache) を利用するかどうか
     # ビルドキャッシュを利用することでバージョンチェックの処理を高速化できる
     # デフォルト: 'true'
     use-cache: ''
+
+    # GitHub Actions が提供するビルドキャッシュ (actions/cache) に渡すパス
+    # キャッシュの除外設定に利用することを想定している
+    # デフォルト: 未使用
+    custom-cache-path: ''
 
     # テストコマンドが成功したときにバージョンの更新をリポジトリに反映するかどうか
     # バージョンのアップデートがあるかどうかをチェックしたいだけなら無効でよい
     # デフォルト: 'false'
     push-on-success: ''
+
+    # デバッグ用途に冗長モードを有効にするかどうか
+    # デフォルト: 'false'
+    verbose: ''
 ```
 
 ### 呼び出し側の設定例
@@ -66,8 +75,11 @@
   with:
     maven-test-command: "test -DfailIfNoTests=false -Dtest='!IntegrationTest'"
     maven-settings-xml-path: "${{ github.workspace }}/settings.xml"
+    custom-cache-path: '!~/.m2/repository/com'
     push-on-success: 'true'
 ```
+
+`custom-cache-path` は [actions/cache](https://github.com/actions/cache) に渡す `path` を記述します。`!` を使うことでキャッシュ対象から除外できます。この例では `~/.m2/repository/com` 配下のディレクトリをすべてキャッシュしない設定になります。
 
 リポジトリに push するには GITHUB_TOKEN や permissions といった認証情報を適切に設定する必要があります。
 

--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,17 @@ inputs:
     description: 'whether cache or not for maven repository'
     required: true
     default: 'true'
+  custom-cache-path:
+    description: 'any (exclude) path patterns for actions/cache'
+    required: false
+    default: ''
   push-on-success:
     description: 'whether git push or not for the dependency version changes when the test succeeded'
     required: true
+    default: 'false'
+  verbose:
+    description: 'whether enable verbose mode, use for debugging'
+    required: false
     default: 'false'
 runs:
   using: "composite"
@@ -33,7 +41,9 @@ runs:
       if: ${{ inputs.use-cache == 'true' }}
       uses: actions/cache@v2
       with:
-        path: ~/.m2/repository
+        path: |
+          ~/.m2/repository/*
+          ${{ inputs.custom-cache-path }}
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
@@ -41,6 +51,11 @@ runs:
       name: Update dependencies with Versions Maven Plugin
       run: |
         source ${{ github.action_path }}/functions.sh
+
+        if [[ "${{ inputs.verbose }}" == "true" ]]; then
+          echo "show the cached repository"
+          sh -c "ls -laR ~/.m2/; exit 0"
+        fi
 
         if [[ -n "${{ inputs.maven-settings-xml-path }}" ]]; then
           set_settings_xml "${{ inputs.maven-settings-xml-path }}"

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: actions/cache@v2
       with:
         path: |
-          ~/.m2/repository/*
+          ~/.m2/repository/*/*
           ${{ inputs.custom-cache-path }}
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |


### PR DESCRIPTION
# 説明

## 背景/意図

java (maven?) では `-SNAPSHOT` という接尾辞を使って開発中の jar のバージョンを表す。github actions のワークフローによってはビルドキャッシュで SNAPSHOT を扱うとトラブルになるケースもある。SNAPSHOT を含む任意のパスをキャッシュ対象外とすることでそういった運用の問題を解決する。

## 変更内容

次のように `custom-cache-path` に [exclude パターン](https://github.com/actions/toolkit/tree/main/packages/glob#exclude-patterns) を記述することで任意のパスをキャッシュ対象外とする。

```yml
- name: Update library versions
  uses: HoshinoResort/hr-library-auto-update@v1
  with:
    maven-test-command: "test -DfailIfNoTests=false -Dtest='!IntegrationTest'"
    maven-settings-xml-path: "${{ github.workspace }}/settings.xml"
    custom-cache-path: '!~/.m2/repository/com/subdomain'
    push-on-success: 'true'
```

## 懸念事項

次の issue にあるように exclude パターンはユーザーの直観通りの振る舞いをするわけではなく、設定方法の組み合わせによっては意図したように除外されない場合がある。あまり要件にあわせた柔軟な設定はできない可能性がある。

* https://github.com/actions/cache/issues/494
* https://github.com/actions/toolkit/issues/713

# リファレンス

* https://github.com/actions/cache
* https://github.com/actions/toolkit